### PR TITLE
add RO build target for badupdate consoles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 *.a
 /Simple 360 NAND Flasher/Release_LTCG
 *.ipch
+
+# User generated files
+*.vcxproj.user
+*.sdf

--- a/AtgFramework2010-installer.bat
+++ b/AtgFramework2010-installer.bat
@@ -1,0 +1,17 @@
+@echo off
+cd /d "%~dp0"
+
+# The 'Common' folders in each project subdirectory contain modified files from XDK example code. We can't include unmodified files from the XDK examples, so this script doesn't overwrite any of the modified files and only adds what is missing.
+# For 32 bit systems %ProgramFiles(x86)% doesn't exist so we need to check for both. 
+
+if exist "%ProgramFiles(x86)%\Microsoft Xbox 360 SDK\Source\Samples\Common\" (
+    echo n | copy /-y "%ProgramFiles(x86)%\Microsoft Xbox 360 SDK\Source\Samples\Common\*" "Simple 360 NAND Flasher\Common"
+    echo n | copy /-y "%ProgramFiles(x86)%\Microsoft Xbox 360 SDK\Source\Samples\Common\*" "NXE2GOD\Common"
+) else if exist "%ProgramFiles%\Microsoft Xbox 360 SDK\Source\Samples\Common\" (
+    echo n | copy /-y "%ProgramFiles%\Microsoft Xbox 360 SDK\Source\Samples\Common\*" "Simple 360 NAND Flasher\Common"
+    echo n | copy /-y "%ProgramFiles%\Microsoft Xbox 360 SDK\Source\Samples\Common\*" "NXE2GOD\Common"
+) else (
+    echo Error: Cannot find the XDK! Make sure it is installed.
+)
+
+pause

--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ At present time i only have 2 projects running, but in due time there will be mo
 If you have any ideas for things i should add or find a bug, feel free to let me know about it, or fork this and fix it ;D
 
 //Swizzy
+
+Building
+========
+
+Requirements:
+- Windows.
+- XDK (version 21256.17 is recommended).
+- Visual Studio 2010.
+
+Before you can build any of the projects here, you need to double click the 'AtgFramework2010-installer.bat' script to populate the source tree with some required files. Then you can open any of the Visual Studio project files.

--- a/Simple 360 NAND Flasher/NandFlasher2010.sln
+++ b/Simple 360 NAND Flasher/NandFlasher2010.sln
@@ -12,6 +12,7 @@ Global
 		Release_German|Xbox 360 = Release_German|Xbox 360
 		Release_Italian|Xbox 360 = Release_Italian|Xbox 360
 		Release_Portuguese|Xbox 360 = Release_Portuguese|Xbox 360
+		Release_RO|Xbox 360 = Release_RO|Xbox 360
 		Release_Russian|Xbox 360 = Release_Russian|Xbox 360
 		Release|Xbox 360 = Release|Xbox 360
 	EndGlobalSection
@@ -25,11 +26,15 @@ Global
 		{652C7D60-BC02-4E09-96DD-930012345678}.Release_Portuguese|Xbox 360.ActiveCfg = Release_Portuguese|Xbox 360
 		{652C7D60-BC02-4E09-96DD-930012345678}.Release_Portuguese|Xbox 360.Build.0 = Release_Portuguese|Xbox 360
 		{652C7D60-BC02-4E09-96DD-930012345678}.Release_Portuguese|Xbox 360.Deploy.0 = Release_Portuguese|Xbox 360
+		{652C7D60-BC02-4E09-96DD-930012345678}.Release_RO|Xbox 360.ActiveCfg = Release_RO|Xbox 360
+		{652C7D60-BC02-4E09-96DD-930012345678}.Release_RO|Xbox 360.Build.0 = Release_RO|Xbox 360
+		{652C7D60-BC02-4E09-96DD-930012345678}.Release_RO|Xbox 360.Deploy.0 = Release_RO|Xbox 360
 		{652C7D60-BC02-4E09-96DD-930012345678}.Release_Russian|Xbox 360.ActiveCfg = Release_Russian|Xbox 360
 		{652C7D60-BC02-4E09-96DD-930012345678}.Release_Russian|Xbox 360.Build.0 = Release_Russian|Xbox 360
 		{652C7D60-BC02-4E09-96DD-930012345678}.Release_Russian|Xbox 360.Deploy.0 = Release_Russian|Xbox 360
 		{652C7D60-BC02-4E09-96DD-930012345678}.Release|Xbox 360.ActiveCfg = Release_English|Xbox 360
 		{652C7D60-BC02-4E09-96DD-930012345678}.Release|Xbox 360.Build.0 = Release_English|Xbox 360
+		{652C7D60-BC02-4E09-96DD-930012345678}.Release|Xbox 360.Deploy.0 = Release_English|Xbox 360
 		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release_German|Xbox 360.ActiveCfg = Release_LTCG|Xbox 360
 		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release_German|Xbox 360.Build.0 = Release_LTCG|Xbox 360
 		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release_German|Xbox 360.Deploy.0 = Release_LTCG|Xbox 360
@@ -39,11 +44,15 @@ Global
 		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release_Portuguese|Xbox 360.ActiveCfg = Release_LTCG|Xbox 360
 		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release_Portuguese|Xbox 360.Build.0 = Release_LTCG|Xbox 360
 		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release_Portuguese|Xbox 360.Deploy.0 = Release_LTCG|Xbox 360
+		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release_RO|Xbox 360.ActiveCfg = Release_LTCG|Xbox 360
+		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release_RO|Xbox 360.Build.0 = Release_LTCG|Xbox 360
+		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release_RO|Xbox 360.Deploy.0 = Release_LTCG|Xbox 360
 		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release_Russian|Xbox 360.ActiveCfg = Release_LTCG|Xbox 360
 		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release_Russian|Xbox 360.Build.0 = Release_LTCG|Xbox 360
 		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release_Russian|Xbox 360.Deploy.0 = Release_LTCG|Xbox 360
 		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release|Xbox 360.ActiveCfg = Release_LTCG|Xbox 360
 		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release|Xbox 360.Build.0 = Release_LTCG|Xbox 360
+		{91D208A6-9936-47FD-9659-67205C3EB0AB}.Release|Xbox 360.Deploy.0 = Release_LTCG|Xbox 360
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Simple 360 NAND Flasher/NandFlasher2010.vcxproj
+++ b/Simple 360 NAND Flasher/NandFlasher2010.vcxproj
@@ -17,6 +17,10 @@
       <Configuration>Release_Portuguese</Configuration>
       <Platform>Xbox 360</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Release_RO|Xbox 360">
+      <Configuration>Release_RO</Configuration>
+      <Platform>Xbox 360</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release_Russian|Xbox 360">
       <Configuration>Release_Russian</Configuration>
       <Platform>Xbox 360</Platform>
@@ -30,6 +34,12 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_English|Xbox 360'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <UseOfAtl>false</UseOfAtl>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_RO|Xbox 360'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
@@ -64,6 +74,9 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_English|Xbox 360'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_RO|Xbox 360'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_Russian|Xbox 360'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -80,11 +93,13 @@
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release_English|Xbox 360'">Release\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release_RO|Xbox 360'">Release_RO\</OutDir>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release_Russian|Xbox 360'">Release_Russian\</OutDir>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release_Portuguese|Xbox 360'">Release_Portuguese\</OutDir>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release_Italian|Xbox 360'">Release_Italian\</OutDir>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release_German|Xbox 360'">Release_German\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release_English|Xbox 360'">Release\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release_RO|Xbox 360'">Release_RO\</IntDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release_Russian|Xbox 360'">Release_Russian\</IntDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release_Portuguese|Xbox 360'">Release_Portuguese\</IntDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release_Italian|Xbox 360'">Release_Italian\</IntDir>
@@ -110,6 +125,59 @@
       <AdditionalIncludeDirectories>Common;..\..\..\Modules;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/MP %(AdditionalOptions)</AdditionalOptions>
       <PreprocessorDefinitions>NDEBUG;_XBOX;XBOX;XBOX_SAMPLE;_XBOX_CRT_DEPRECATE_INSECURE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <AnalyzeStalls>false</AnalyzeStalls>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/ignore:4089  %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>xapilib.lib;vcomp.lib;d3d9ltcg.lib;d3dx9.lib;xgraphics.lib;xapilib.lib;xaudio2.lib;x3daudioltcg.lib;xmcoreltcg.lib;xboxkrnl.lib;xbdm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <SetChecksum>true</SetChecksum>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
+    <ImageXex>
+      <ConfigurationFile>xex.xml</ConfigurationFile>
+      <AdditionalSections>font=$(OutDir)\font.xpr,RO</AdditionalSections>
+      <SuppressStartupBanner>false</SuppressStartupBanner>
+      <AllowControllerSwapping>true</AllowControllerSwapping>
+    </ImageXex>
+    <Deploy>
+      <DeploymentType>CopyToHardDrive</DeploymentType>
+      <DvdEmulationType>ZeroSeekTimes</DvdEmulationType>
+      <DeploymentFiles>$(RemoteRoot)=$(ImagePath)</DeploymentFiles>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </Deploy>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_RO|Xbox 360'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Full</Optimization>
+      <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
+      <StringPooling>true</StringPooling>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <OpenMPSupport>FALSE</OpenMPSupport>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <AdditionalIncludeDirectories>Common;..\..\..\Modules;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/MP %(AdditionalOptions)</AdditionalOptions>
+      <PreprocessorDefinitions>NDEBUG;_XBOX;XBOX;XBOX_SAMPLE;_XBOX_CRT_DEPRECATE_INSECURE;READ_ONLY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>

--- a/Simple 360 NAND Flasher/Translations/Default.h
+++ b/Simple 360 NAND Flasher/Translations/Default.h
@@ -152,4 +152,7 @@
 #define MSG_GAME_NOT_MOUNTED_TRYING_HDD "game:\\ isn't mounted, checking if a hdd is available...\n"
 #define MSG_GAME_NOT_MOUNTED "game:\\ isn't mounted, unable to continue!\n"
 
+#define MSG_READ_ONLY_RETURNING_TO_MANUAL_MODE "NAND flashing is disabled in this build.\nReturning to Manual Mode!\n" 
+#define MSG_READ_ONLY_NOTICE "Notice: NAND flashing is disabled in this build\n"
+
 #endif

--- a/Simple 360 NAND Flasher/nandflasher_1.cpp
+++ b/Simple 360 NAND Flasher/nandflasher_1.cpp
@@ -290,6 +290,16 @@ void TryAutoMode()
 		AutoMode = true;
 		dprintf(MSG_SIMPLEFLASHER_CMD_FOUND_ENTERING_AUTO);
 		int mode = CheckMode("game:\\simpleflasher.cmd");
+
+#ifdef READ_ONLY
+		if ( (mode == 2) || (mode == 3) )
+		{
+			dprintf(MSG_READ_ONLY_RETURNING_TO_MANUAL_MODE);
+			AutoMode = false;
+			return;
+		}
+#endif
+
 		if (mode == 1) //AutoDump
 		{
 			dprintf(MSG_AUTO_DUMP_FOUND);
@@ -392,8 +402,11 @@ VOID __cdecl main()
 	MakeConsole("embed:\\font", CONSOLE_COLOR_BLACK, CONSOLE_COLOR_GOLD);
 	if (!CheckGameMounted())
 		return;
+
+#ifndef READ_ONLY
 	write = fexists("game:\\updflash.bin");
-	
+#endif
+
 #ifdef TRANSLATION_BY
 #ifdef USE_UNICODE
 	dprintf(L"Simple 360 NAND Flasher by Swizzy v1.5 (BETA)\n");
@@ -404,6 +417,11 @@ VOID __cdecl main()
 #else
 	dprintf("Simple 360 NAND Flasher by Swizzy v1.5 (BETA)\n\n");
 #endif
+
+#ifdef READ_ONLY
+	dprintf(MSG_READ_ONLY_NOTICE);
+#endif
+
 	dprintf(MSG_DETECTING_NAND_TYPE);
 	MMC = (sfcx_detecttype() == 1); // 1 = MMC, 0 = RAW NAND
 	if (!MMC)


### PR DESCRIPTION
Hello there. First of all thank you for your guidance in building these projects. The goal I had with Simple 360 Nand Flasher was to make a build target that disabled all NAND flashing functionality. With BadUpdate now allowing Xbox 360 consoles to run this program to backup their NAND, I think it is good to be able to have a build of this program that blocks users from writing said backup back (instant brick). Changes:

* RELEASE_RO target discloses the fact that the built executable does not support NAND flashing. Both auto-mode and manual mode are changed with a CFLAG passed by this 'READ_ONLY'.
* Added some user generated visual studio file extensions to .gitignore.
* Added build instructions to readme.md.
* Added a batch script that can install all the files into both projects without overwriting the existing ones you have modified and have their already. Just double click that script in the source.

If you think anything can be done better here, please let me know. 